### PR TITLE
Added new cloudmesh.common shlex function that supports windows paths.

### DIFF
--- a/cloudmesh/shell/command.py
+++ b/cloudmesh/shell/command.py
@@ -1,6 +1,7 @@
-import shlex
+#import shlex
 import textwrap
 
+from cloudmesh.common import shlex
 from cloudmesh.common.console import Console
 from cloudmesh.common.dotdict import dotdict
 from docopt import docopt


### PR DESCRIPTION
This update adds the new shlex function in cloudmesh-common that supports both linxu and windows paths.

Previously the builtin python `shlex` function was used, which does not function properly on windows (see https://docs.python.org/3/library/shlex.html#shlex.quote).  This update fixes all `@command` functions, which will allow windows paths with `\\` to not be stripped.