### PR TITLE
add raw string

### DIFF
--- a/cloudmesh/shell/shell.py
+++ b/cloudmesh/shell/shell.py
@@ -187,7 +187,7 @@ class CMShell(Cmd, PluginCommandClasses):
     The command shell that inherits all commands from PluginCommand
     """
     prompt = 'cms> '
-    banner = textwrap.dedent("""
+    banner = textwrap.dedent(r"""
     +-------------------------------------------------------+
     |   ____ _                 _                     _      |
     |  / ___| | ___  _   _  __| |_ __ ___   ___  ___| |__   |


### PR DESCRIPTION
We are getting an error when using cmd5 in Python 3.12
```bash
~/cm/cloudmesh-cmd5/cloudmesh/shell/shell.py:190: SyntaxWarning: invalid escape sequence '\|'
banner = textwrap.dedent("""
```

this is easily solved by making the string raw.
r"""